### PR TITLE
feat(US-1): Notion Poller + Claim System

### DIFF
--- a/novaos/core/concurrency.py
+++ b/novaos/core/concurrency.py
@@ -1,0 +1,116 @@
+"""Concurrency management for NovaOS.
+
+v0.1 Policy:
+- Global worker pool: 3 concurrent workers (configurable)
+- Per-repo concurrency: 1 (serialized to avoid conflicts)
+"""
+import asyncio
+from typing import Dict, Set
+from dataclasses import dataclass
+
+
+@dataclass
+class ConcurrencyPolicy:
+    """v0.1 concurrency settings."""
+    global_pool_size: int = 3
+    per_repo_concurrency: int = 1
+
+
+class ConcurrencyManager:
+    """Manages concurrent execution respecting policy."""
+    
+    def __init__(self, policy: ConcurrencyPolicy = None):
+        self.policy = policy or ConcurrencyPolicy()
+        
+        # Global semaphore for worker pool
+        self.global_semaphore = asyncio.Semaphore(self.policy.global_pool_size)
+        
+        # Per-repo locks (repo -> semaphore)
+        self._repo_locks: Dict[str, asyncio.Semaphore] = {}
+        
+        # Track active runs per repo
+        self._active_runs: Dict[str, Set[str]] = {}
+    
+    async def acquire_repo_lock(self, repo: str, run_id: str) -> bool:
+        """
+        Try to acquire lock for repo.
+        
+        Returns True if acquired, False if repo is busy.
+        """
+        if repo not in self._repo_locks:
+            self._repo_locks[repo] = asyncio.Semaphore(self.policy.per_repo_concurrency)
+            self._active_runs[repo] = set()
+        
+        # Try to acquire without blocking
+        if self._repo_locks[repo].locked():
+            return False
+        
+        await self._repo_locks[repo].acquire()
+        self._active_runs[repo].add(run_id)
+        return True
+    
+    def release_repo_lock(self, repo: str, run_id: str):
+        """Release lock for repo."""
+        if repo in self._active_runs and run_id in self._active_runs[repo]:
+            self._active_runs[repo].discard(run_id)
+        
+        if repo in self._repo_locks:
+            try:
+                self._repo_locks[repo].release()
+            except ValueError:
+                # Already released
+                pass
+    
+    def is_repo_busy(self, repo: str) -> bool:
+        """Check if repo has active workers."""
+        if repo not in self._active_runs:
+            return False
+        return len(self._active_runs[repo]) >= self.policy.per_repo_concurrency
+    
+    async def execute_with_limits(self, repo: str, run_id: str, coro):
+        """
+        Execute coroutine respecting both global and per-repo limits.
+        
+        Usage:
+            result = await concurrency_manager.execute_with_limits(
+                "papkot-ai", run_id, worker.execute()
+            )
+        """
+        async with self.global_semaphore:
+            # Try to acquire repo lock
+            if not await self.acquire_repo_lock(repo, run_id):
+                raise RepoBusyError(f"Repo {repo} is busy with another task")
+            
+            try:
+                return await coro
+            finally:
+                self.release_repo_lock(repo, run_id)
+    
+    def get_status(self) -> Dict:
+        """Get current concurrency status."""
+        return {
+            "global_limit": self.policy.global_pool_size,
+            "global_available": self.policy.global_pool_size - (self.global_semaphore._value or 0),
+            "per_repo_limit": self.policy.per_repo_concurrency,
+            "active_repos": {
+                repo: len(runs) 
+                for repo, runs in self._active_runs.items()
+            }
+        }
+
+
+class RepoBusyError(Exception):
+    """Raised when trying to work on a repo that's already busy."""
+    pass
+
+
+# Singleton
+_manager: ConcurrencyManager = None
+
+
+def get_concurrency_manager() -> ConcurrencyManager:
+    """Get singleton concurrency manager."""
+    global _manager
+    if _manager is None:
+        _manager = ConcurrencyManager()
+    return _manager

--- a/novaos/core/poller.py
+++ b/novaos/core/poller.py
@@ -1,0 +1,189 @@
+"""Notion poller - discovers and claims tasks."""
+import os
+from datetime import datetime, timedelta
+from typing import List, Dict, Any, Optional
+
+from notion_client import Client
+
+from novaos.db.supabase_client import get_db, SupabaseClient
+from novaos.core.state_machine import RunState
+
+
+class NotionPoller:
+    """Polls Notion for tasks ready for agent processing."""
+    
+    def __init__(self, db: SupabaseClient = None):
+        self.notion = Client(auth=os.getenv("NOTION_TOKEN"))
+        self.database_id = os.getenv("NOTION_DATABASE_ID")
+        self.db = db or get_db()
+    
+    def query_ready_tasks(self) -> List[Dict[str, Any]]:
+        """
+        Query Notion for tasks with:
+        - Status = "Agent's Turn"
+        - novaos_run_id is empty (not yet claimed)
+        """
+        try:
+            response = self.notion.databases.query(
+                database_id=self.database_id,
+                filter={
+                    "and": [
+                        {
+                            "property": "Status",
+                            "status": {
+                                "equals": "Agent's Turn"
+                            }
+                        }
+                    ]
+                }
+            )
+            
+            tasks = []
+            for page in response.get("results", []):
+                properties = page.get("properties", {})
+                
+                # Check if already claimed (novaos_run_id exists)
+                run_id_prop = properties.get("novaos_run_id", {})
+                if run_id_prop.get("rich_text"):
+                    # Already claimed, skip
+                    continue
+                
+                task = {
+                    "page_id": page["id"],
+                    "url": page["url"],
+                    "title": self._extract_title(properties),
+                    "description": self._extract_description(properties),
+                    "repo": self._extract_repo(properties),
+                    "created_time": page["created_time"]
+                }
+                tasks.append(task)
+            
+            return tasks
+            
+        except Exception as e:
+            print(f"Error querying Notion: {e}")
+            return []
+    
+    def _extract_title(self, properties: Dict) -> str:
+        """Extract title from page properties."""
+        title_prop = properties.get("Name", properties.get("Title", {}))
+        if "title" in title_prop:
+            return "".join([t["plain_text"] for t in title_prop["title"]])
+        return "Untitled"
+    
+    def _extract_description(self, properties: Dict) -> str:
+        """Extract description if available."""
+        # Look for common description fields
+        for key in ["Description", "description", "Notes", "notes", "Content", "content"]:
+            if key in properties:
+                prop = properties[key]
+                if "rich_text" in prop:
+                    return "".join([t["plain_text"] for t in prop["rich_text"]])
+        return ""
+    
+    def _extract_repo(self, properties: Dict) -> str:
+        """Extract target repo from properties."""
+        # Look for repo field
+        for key in ["Repo", "Repository", "repo", "repository", "Project", "project"]:
+            if key in properties:
+                prop = properties[key]
+                if "select" in prop and prop["select"]:
+                    return prop["select"]["name"]
+                if "rich_text" in prop:
+                    text = "".join([t["plain_text"] for t in prop["rich_text"]])
+                    if text:
+                        return text
+        # Default based on context or raise error
+        return "papkot-ai"  # Default for v0.1
+    
+    def claim_task(self, task: Dict[str, Any]) -> Optional[str]:
+        """
+        Claim a task atomically.
+        
+        1. Insert into Supabase (unique constraint prevents duplicates)
+        2. Update Notion with run_id
+        
+        Returns run_id if successful, None if already claimed.
+        """
+        page_id = task["page_id"]
+        
+        # Try to claim in Supabase first (atomic due to unique constraint)
+        run_id = self.db.claim_task(
+            notion_page_id=page_id,
+            title=task["title"],
+            description=task["description"],
+            repo=task["repo"]
+        )
+        
+        if not run_id:
+            # Already claimed
+            print(f"Task {page_id} already claimed, skipping")
+            return None
+        
+        # Update Notion with run_id
+        try:
+            self.notion.pages.update(
+                page_id=page_id,
+                properties={
+                    "novaos_run_id": {
+                        "rich_text": [
+                            {
+                                "text": {"content": run_id}
+                            }
+                        ]
+                    }
+                }
+            )
+            print(f"Claimed task {page_id} with run_id {run_id}")
+            return run_id
+            
+        except Exception as e:
+            # If Notion update fails, we should rollback the claim
+            # For v0.1, we'll log and let it timeout
+            print(f"Error updating Notion (claim will timeout): {e}")
+            return run_id
+    
+    def poll_and_claim(self) -> List[str]:
+        """
+        Main polling loop.
+        
+        Returns list of newly claimed run_ids.
+        """
+        print(f"[{datetime.utcnow().isoformat()}] Polling Notion...")
+        
+        # Release stale claims first
+        released = self.db.release_stale_claims(timeout_minutes=30)
+        if released > 0:
+            print(f"Released {released} stale claims")
+        
+        # Query for ready tasks
+        tasks = self.query_ready_tasks()
+        print(f"Found {len(tasks)} ready tasks")
+        
+        # Claim each task
+        claimed = []
+        for task in tasks:
+            run_id = self.claim_task(task)
+            if run_id:
+                claimed.append(run_id)
+        
+        print(f"Claimed {len(claimed)} tasks")
+        return claimed
+
+
+def run_poller_once():
+    """Run one poll cycle (for cron/testing)."""
+    poller = NotionPoller()
+    return poller.poll_and_claim()
+
+
+if __name__ == "__main__":
+    # Test mode
+    import sys
+    sys.path.insert(0, "/Users/mmi/Go/NovaStudio/projects/nova-os")
+    
+    from dotenv import load_dotenv
+    load_dotenv()
+    
+    claimed = run_poller_once()
+    print(f"Claimed: {claimed}")

--- a/novaos/core/state_machine.py
+++ b/novaos/core/state_machine.py
@@ -1,0 +1,59 @@
+"""State machine definitions and transitions for NovaOS."""
+from enum import Enum
+from typing import Set, Dict, List
+
+
+class RunState(str, Enum):
+    """Valid states for a run."""
+    PENDING = "PENDING"
+    CLAIMED = "CLAIMED"
+    WORKING = "WORKING"
+    VALIDATING = "VALIDATING"
+    MERGING = "MERGING"
+    DONE = "DONE"
+    FAILED = "FAILED"
+    BLOCKED = "BLOCKED"
+
+
+class IssueState(str, Enum):
+    """Valid states for an issue."""
+    OPEN = "open"
+    IN_PROGRESS = "in_progress"
+    CLOSED = "closed"
+
+
+# Valid state transitions
+VALID_TRANSITIONS: Dict[RunState, Set[RunState]] = {
+    RunState.PENDING: {RunState.CLAIMED},
+    RunState.CLAIMED: {RunState.WORKING, RunState.FAILED, RunState.BLOCKED},
+    RunState.WORKING: {RunState.VALIDATING, RunState.FAILED, RunState.BLOCKED},
+    RunState.VALIDATING: {RunState.MERGING, RunState.BLOCKED, RunState.FAILED},
+    RunState.MERGING: {RunState.DONE, RunState.FAILED, RunState.BLOCKED},
+    RunState.BLOCKED: {RunState.WORKING, RunState.MERGING, RunState.FAILED},
+    RunState.FAILED: set(),  # Terminal state
+    RunState.DONE: set(),    # Terminal state
+}
+
+
+def is_valid_transition(from_state: RunState, to_state: RunState) -> bool:
+    """Check if transition is allowed."""
+    if from_state not in VALID_TRANSITIONS:
+        return False
+    return to_state in VALID_TRANSITIONS[from_state]
+
+
+def get_allowed_transitions(state: RunState) -> List[RunState]:
+    """Get list of allowed next states."""
+    if state not in VALID_TRANSITIONS:
+        return []
+    return list(VALID_TRANSITIONS[state])
+
+
+def get_terminal_states() -> Set[RunState]:
+    """Get states that cannot transition further."""
+    return {RunState.DONE, RunState.FAILED}
+
+
+def requires_human_approval(state: RunState) -> bool:
+    """Check if state requires human intervention."""
+    return state == RunState.BLOCKED

--- a/novaos/db/supabase_client.py
+++ b/novaos/db/supabase_client.py
@@ -1,0 +1,211 @@
+"""Supabase client for NovaOS - single source of truth."""
+import os
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any, List
+from uuid import uuid4
+
+from supabase import create_client, Client
+
+
+class SupabaseClient:
+    """Manages all database operations with idempotency guarantees."""
+    
+    def __init__(self):
+        self.url = os.getenv("SUPABASE_URL")
+        self.key = os.getenv("SUPABASE_KEY")
+        if not self.url or not self.key:
+            raise ValueError("SUPABASE_URL and SUPABASE_KEY required")
+        self.client: Client = create_client(self.url, self.key)
+    
+    def claim_task(self, notion_page_id: str, title: str, 
+                   description: str, repo: str) -> Optional[str]:
+        """
+        Atomically claim a Notion task.
+        
+        Returns run_id if claimed, None if already claimed (idempotent).
+        Uses unique constraint on notion_page_id to prevent races.
+        """
+        run_id = str(uuid4())
+        
+        try:
+            # Try to insert - will fail if notion_page_id already exists
+            result = self.client.table("runs").insert({
+                "id": run_id,
+                "notion_page_id": notion_page_id,
+                "state": "CLAIMED",
+                "title": title,
+                "description": description,
+                "repo": repo,
+                "claimed_at": datetime.utcnow().isoformat(),
+                "retry_count": 0
+            }).execute()
+            
+            # Log the transition
+            self.log_transition(run_id, None, "CLAIMED", "Task claimed from Notion")
+            
+            return run_id
+            
+        except Exception as e:
+            # Unique constraint violation = already claimed
+            if "duplicate" in str(e).lower() or "unique" in str(e).lower():
+                return None
+            raise
+    
+    def get_run(self, run_id: str) -> Optional[Dict[str, Any]]:
+        """Get run by ID."""
+        result = self.client.table("runs").select("*").eq("id", run_id).execute()
+        if result.data:
+            return result.data[0]
+        return None
+    
+    def get_run_by_notion(self, notion_page_id: str) -> Optional[Dict[str, Any]]:
+        """Get run by Notion page ID."""
+        result = self.client.table("runs").select("*").eq("notion_page_id", notion_page_id).execute()
+        if result.data:
+            return result.data[0]
+        return None
+    
+    def update_run_state(self, run_id: str, new_state: str, 
+                         reason: str = "", metadata: Dict = None) -> bool:
+        """Update run state with transition logging."""
+        # Get current state
+        run = self.get_run(run_id)
+        if not run:
+            return False
+        
+        old_state = run.get("state")
+        
+        # Update the run
+        update_data = {
+            "state": new_state,
+            "updated_at": datetime.utcnow().isoformat()
+        }
+        
+        if new_state == "DONE":
+            update_data["completed_at"] = datetime.utcnow().isoformat()
+        
+        if metadata:
+            # Merge with existing metadata if any
+            existing_metadata = run.get("metadata") or {}
+            existing_metadata.update(metadata)
+            update_data["metadata"] = existing_metadata
+        
+        self.client.table("runs").update(update_data).eq("id", run_id).execute()
+        
+        # Log transition
+        self.log_transition(run_id, old_state, new_state, reason, metadata)
+        
+        return True
+    
+    def create_issue(self, run_id: str, issue_number: int, 
+                     issue_url: str, title: str, worker_type: str,
+                     description: str = "") -> bool:
+        """Create run_issue record (idempotent per run_id + worker_type)."""
+        try:
+            # Check if issue already exists for this worker type
+            existing = self.client.table("run_issues").select("*").eq("run_id", run_id).eq("worker_type", worker_type).execute()
+            
+            if existing.data:
+                # Already exists, update it
+                self.client.table("run_issues").update({
+                    "issue_number": issue_number,
+                    "issue_url": issue_url,
+                    "title": title,
+                    "description": description,
+                    "status": "open",
+                    "updated_at": datetime.utcnow().isoformat()
+                }).eq("run_id", run_id).eq("worker_type", worker_type).execute()
+            else:
+                # Create new
+                self.client.table("run_issues").insert({
+                    "run_id": run_id,
+                    "issue_number": issue_number,
+                    "issue_url": issue_url,
+                    "title": title,
+                    "description": description,
+                    "worker_type": worker_type,
+                    "status": "open"
+                }).execute()
+            
+            return True
+        except Exception as e:
+            print(f"Error creating issue: {e}")
+            return False
+    
+    def update_issue_status(self, run_id: str, worker_type: str,
+                           status: str, pr_url: str = None) -> bool:
+        """Update issue status and PR URL."""
+        update_data = {
+            "status": status,
+            "updated_at": datetime.utcnow().isoformat()
+        }
+        if pr_url:
+            update_data["pr_url"] = pr_url
+        
+        self.client.table("run_issues").update(update_data).eq("run_id", run_id).eq("worker_type", worker_type).execute()
+        return True
+    
+    def get_run_issues(self, run_id: str) -> List[Dict[str, Any]]:
+        """Get all issues for a run."""
+        result = self.client.table("run_issues").select("*").eq("run_id", run_id).execute()
+        return result.data or []
+    
+    def are_all_issues_closed(self, run_id: str) -> bool:
+        """Check if all issues for a run are closed."""
+        issues = self.get_run_issues(run_id)
+        if not issues:
+            return False
+        return all(issue.get("status") == "closed" for issue in issues)
+    
+    def log_transition(self, run_id: str, from_state: Optional[str],
+                       to_state: str, reason: str = "", 
+                       metadata: Dict = None):
+        """Log state transition for audit."""
+        self.client.table("run_transitions").insert({
+            "run_id": run_id,
+            "from_state": from_state,
+            "to_state": to_state,
+            "reason": reason,
+            "metadata": metadata or {}
+        }).execute()
+    
+    def get_pending_runs(self) -> List[Dict[str, Any]]:
+        """Get all runs in PENDING state (for poller)."""
+        # Actually we query Notion directly, but this is useful for debugging
+        result = self.client.table("runs").select("*").eq("state", "PENDING").execute()
+        return result.data or []
+    
+    def get_claimed_runs(self) -> List[Dict[str, Any]]:
+        """Get all claimed runs that haven't started working."""
+        result = self.client.table("runs").select("*").eq("state", "CLAIMED").execute()
+        return result.data or []
+    
+    def release_stale_claims(self, timeout_minutes: int = 30) -> int:
+        """Release claims that haven't progressed in timeout_minutes."""
+        cutoff = datetime.utcnow() - timedelta(minutes=timeout_minutes)
+        
+        # Find stale claimed runs
+        result = self.client.table("runs").select("*").eq("state", "CLAIMED").lt("claimed_at", cutoff.isoformat()).execute()
+        
+        released = 0
+        for run in result.data or []:
+            self.update_run_state(
+                run["id"], 
+                "PENDING",
+                f"Claim released after {timeout_minutes}min timeout"
+            )
+            released += 1
+        
+        return released
+
+
+# Singleton instance
+_db: Optional[SupabaseClient] = None
+
+
+def get_db() -> SupabaseClient:
+    """Get or create Supabase client singleton."""
+    global _db
+    if _db is None:
+        _db = SupabaseClient()
+    return _db

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,29 @@
+# NovaOS v0.1 Dependencies
+# Core
 langgraph>=0.0.40
 langchain>=0.1.0
 pydantic>=2.0.0
 python-dotenv>=1.0.0
+
+# Database
 supabase>=2.0.0
+
+# Notion
+notion-client>=2.2.1
+
+# APIs
 httpx>=0.25.0
 python-telegram-bot>=20.0
+
+# Git/GitHub
 GitPython>=3.1.40
 pygithub>=2.1.1
+
+# Validation
 ruff>=0.1.0
 mypy>=1.7.0
 pytest>=7.4.0
+
+# Utilities
 pyyaml>=6.0.1
 schedule>=1.2.0


### PR DESCRIPTION
feat(US-1): Notion Poller + Claim System

Implements the entry point for NovaOS - polling Notion and claiming tasks with proper idempotency.

## Changes
- Supabase Client: Atomic claim with unique constraint, transition logging, stale claim cleanup
- State Machine: Valid states and transitions
- Concurrency: Global pool (3) + per-repo (1) limits
- Poller: Notion query, atomic claim, run_id writeback
- Makefile/justfile: Canonical commands for agents

## Key Design Decisions
1. Idempotency: notion_page_id UNIQUE constraint prevents duplicate runs
2. Lock Strategy: Supabase row = lock, 30min timeout for stale claims
3. Concurrency: Serial per repo (v0.1), global pool prevents overload

Closes #1
